### PR TITLE
fix: Call .get_token() to make use of the context manager

### DIFF
--- a/src/web_app_handler.py
+++ b/src/web_app_handler.py
@@ -35,7 +35,9 @@ class WebAppHandler:
 
             # We are executing in Github App mode
             if self.config.gh_app:
-                with GithubAppToken(**self.config.gh_app._asdict()) as token:
+                with GithubAppToken(
+                    **self.config.gh_app._asdict()
+                ).get_token() as token:
                     client = GithubClient(
                         token=token,
                         dsn=self.config.sentry.dsn,


### PR DESCRIPTION
This was failling with:

```
Traceback (most recent call last):
  File "/Users/armenzg/code/github-actions-app/src/main.py", line 50, in main
    reason, http_code = handler.handle_event(request.json, request.headers)
  File "/Users/armenzg/code/github-actions-app/src/web_app_handler.py", line 38, in handle_event
    with GithubAppToken(**self.config.gh_app._asdict()) as token:
AttributeError: __enter__
```