### PR TITLE
fix(ci): Ignore missing commits when creating a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,15 @@ jobs:
           fetch-depth: 0
 
       - name: Create Sentry release
-        uses: getsentry/action-release@master
+        uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
         with:
           projects: "sentry-github-actions-app"
           environment: production
+          # We have created releases from the PR, thus, the CLI gets confused finding commits
+          ignore_missing: true
 
   docker-build:
     name: Docker build


### PR DESCRIPTION
Finding commits for releases [fails on master](https://github.com/getsentry/sentry-github-actions-app/runs/7411633220?check_suite_focus=true) and it's probably because I created releases on the PR.
For now, let's ignore the problem.

For instance, before I git forced this PR. I managed to create [another release](https://sentry.io/organizations/sentry/releases/4b1a7a12b72b341d5d502910af5bafa2e8289c12/?project=5903949) for this app:
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/44410/179978552-2e5dffd6-1ee8-4dc9-af27-5573e36b5142.png">

Also, I upgrade to the official version of the action.