### PR TITLE
ref: Remove action-release and try auto-associate-commits-to-release feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,32 +11,6 @@ on:
       - "**.md"
 
 jobs:
-  # In reality, this will not be completely accurate as only when a Docker image is deployed to GCP
-  # we will truly have a deployed release. Nevertheless, this will be useful once it is deployed
-  # since it will help add commits to releases
-  release:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    name: Create a Sentry release
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          # This is necessary for the a release to include commits
-          fetch-depth: 0
-
-      - name: Create Sentry release
-        uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-        with:
-          projects: "sentry-github-actions-app"
-          environment: production
-          # We have created releases from the PR, thus, the CLI gets confused finding commits
-          ignore_missing: true
-
   docker-build:
     name: Docker build
     runs-on: ubuntu-latest


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/36491 a new feature was landed to associate commits to releases via the SDK.
I've also set up code mappings because I believe this is needed.