### PR TITLE
feat: Customers to define their DSN via repo & config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Steps to follow:
 - Create a Sentry project to gather your Github CI data
   - You don't need to select a platform in the wizard or any alerts
   - Find the DSN key under the settings of the project you created
-- Create a public repo name `.sentry`
+- Create a private repo named `.sentry`
 - Create a file in that repo called `sentry_config.ini` with these contents (adjust your DSN value)
 
 ```ini

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sentry Github Actions App
 
-**NOTE**: You can try this project but you will need to deploy your own ingestion app. If this is a project you would like us to invest in, please let us know in [this issue](https://github.com/getsentry/sentry-github-actions-app/issues/46).
+**NOTE**: If this is a project you would like us to invest in, please let us know in [this issue](https://github.com/getsentry/sentry-github-actions-app/issues/46).
 
 This app allows your organization to instrument Github Actions with Sentry. You can use this to get insights of what parts of your CI are slow or failing often.
 
@@ -22,7 +22,6 @@ This screenshot shows the transaction view for an individual Github Action showi
 
 <img width="992" alt="image" src="https://user-images.githubusercontent.com/44410/175558737-7eca4036-73ce-4ed2-8b5a-51b5d882a814.png">
 
-
 ## Features
 
 Here's a list of benefits you will get if you use this project:
@@ -36,94 +35,28 @@ Here's a list of benefits you will get if you use this project:
   - For instance you can show: slowest jobs, most failing jobs, jobs requirying re-runs, repos consuming most CI
   - Some of the main tags by which you can slice the data: workflow file, repo, branch, commit, job_status, pull_request, run_attempt
 
-
 ## Do you want to try this?
-
-**NOTE**: If we invested a bit more on this project we would reduce the following steps to just install this Github App and add this configuration file somewhere to be determined.
 
 Steps to follow:
 
-- Fork the app
-- Create a Docker build
-- Deploy the image to your provider
-  - If you don't use GCP you may need to make some changes to the code
-- Create a Github App and install it in all your repos
-  - Instructions are provided below
+- Create a Sentry project to gather your Github CI data
+  - You don't need to select a platform in the wizard or any alerts
+  - Find the DSN key under the settings of the project you created
+- Create a public repo name `.sentry`
+- Create a file in that repo called `sentry_config.ini` with these contents (adjust your DSN value)
 
-Please, give us some feedback in [this issue](https://github.com/getsentry/sentry-github-actions-app/issues/46).
+```ini
+[sentry-github-actions-app]
+; DSN value of the Sentry project you created in the
+dsn = https://foo@bar.ingest.sentry.io/foobar
+```
 
-## Code
+- Install this Github App for all your repos
+  - We only request workflow jobs and a single file permissions
 
-Code explanation:
+**NOTE**: In other words, we won't be able to access any of your code.
 
-- `github_sdk.py` has the generic logic to submit Github jobs as Sentry transactions. This module could be released separatedly.
-- `github_app.py` contains code to handle a Github App installation.
-- `web_app_handler.py`: Web app logic goes here.
-- `main.py` contains the code to respond to webhook events.
-
-## Set Up
-
-**NOTE**: Currently, this app is only used internally. See [milestone](https://github.com/getsentry/sentry-github-actions-app/milestone/1) for required work to support ingesting data from other orgs.
-
-These are the steps you will need to set up this backend and Github app for your organization.
-
-The steps of the next two sections are related. You will be generating keys and variables that are need to configure each component (the backend and the Github App), thus, you will need to go back and forth.
-
-### Sentry SaaS (or self-hosted Sentry)
-
-In Sentry.io:
-
-- Create a project to track errors of the backend itself (`APP_DSN` in section below)
-- Create a project to track Github jobs (`SENTRY_GITHUB_DSN` in section below)
-
-### Backend deployment
-
-- Deploy the app to a service (e.g. GCP) and make it publicly reachable
-  - Take note of the app's URL and use it when creating the Github app webhook
-
-Common environment variables:
-
-- `APP_DSN`: Report your deployment errors to Sentry
-- `GH_WEBHOOK_SECRET`: Secret shared between Github's webhook and your app
-  - Create a secret with `python3 -c 'import secrets; print(secrets.token_urlsafe(20))'` on your command line
-- `SENTRY_GITHUB_DSN`: Where to report your Github job transactions
-- `LOGGING_LEVEL` (optional): To set the verbosity of Python's logging (defaults to INFO)
-
-Github App specific variables:
-
-- `GH_APP_ID` - Github App ID
-  - When you create the Github App, you will see the value listed in the page
-- `GH_APP_INSTALLATION_ID` - Github App Installation ID
-  - Once you install the app under your Github org, you will see it listed as one of your organizations' integrations
-  - If you load the page, you will see the ID as part of the URL
-- `GH_APP_PRIVATE_KEY` - Private key
-  - When you load the Github App page, at the bottom of the page under "Private Keys" select "Generate a private key"
-  - A .pem file will be downloaded locally.
-  - Convert it into a single line value by using base64 (`base64 -i path_to_pem_file`)
-
-For local development, you need to make the App's webhook point to your ngrok set up. You should create a new private key (a .pem file that gets automatically downloaded when generated) for your local development and do not forget to delete the private key when you are done.
-
-### The Github App
-
-After creating the Github App for the first time there are some changes you need to make:
-
-- Configure the Webhook URL to point to the backend deployment
-- Set the Webhook Secret to be the same as the backend deployment
-- Set the following permissions for the app:
-  - Actions: Workflows, workflow runs and artifacts -> Read-only
-   - Specific events: [Workflow job](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_job)
-
-After completing the creation of the app you will need to make few more changes:
-
-- Click on `Generate a private key`
-  - Run `base64 -i <path_to_download_file>`
-  - Store the value in Google Secrets
-  - Delete the file just downloaded
-- Add to the deployment the variable `GH_APP_ID`
-- Select "Install App" and install the app on your Github org
-  - Grant access to "All Repositories"
-- Look at the URL of the installation and you will find the installation ID
-  - Add to the deployment the variable `GH_APP_INSTALLATION_ID`
+Give us feedback in [this issue](https://github.com/getsentry/sentry-github-actions-app/issues/46).
 
 ## Local development
 

--- a/setup.md
+++ b/setup.md
@@ -1,0 +1,56 @@
+# Set-up
+
+This page includes information about our deployment. No need to be read by customers installing the Github App.
+
+## Backend deployment
+
+In Sentry.io, we created a project to track errors of the backend itself (`APP_DSN` in section below).
+
+The app is deployed via GC. The app's deployment is in the webhook url for the Github app. Currently the deployment requires manual intervention.
+
+Common environment variables:
+
+- `APP_DSN`: Report your deployment errors to Sentry
+- `GH_WEBHOOK_SECRET`: Secret shared between Github's webhook and your app
+  - Create a secret with `python3 -c 'import secrets; print(secrets.token_urlsafe(20))'` on your command line
+- `LOGGING_LEVEL` (optional): To set the verbosity of Python's logging (defaults to INFO)
+
+Github App specific variables:
+
+- `GH_APP_ID` - Github App ID
+  - When you create the Github App, you will see the value listed in the page
+- `GH_APP_INSTALLATION_ID` - Github App Installation ID
+  - Once you install the app under your Github org, you will see it listed as one of your organizations' integrations
+  - If you load the page, you will see the ID as part of the URL
+- `GH_APP_PRIVATE_KEY` - Private key
+  - When you load the Github App page, at the bottom of the page under "Private Keys" select "Generate a private key"
+  - A .pem file will be downloaded locally.
+  - Convert it into a single line value by using base64 (`base64 -i path_to_pem_file`) and delete it
+
+For local development, you need to make the App's webhook point to your ngrok set up. You should create a new private key (a .pem file that gets automatically downloaded when generated) for your local development and do not forget to delete the private key when you are done.
+
+## The Github App
+
+**NOTE**: Only Sentry Github Admins can make changes to the app
+
+Configuration taken after creating the app:
+
+- Configure the Webhook URL to point to the backend deployment
+- Set the Webhook Secret to be the same as the backend deployment
+- Set the following permissions for the app:
+  - Actions: Workflows, workflow runs and artifacts -> Read-only
+  - Singe File: sentry_config.ini
+  - Subscribe to events:
+    - [Workflow job](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_job)
+
+After completing the creation of the app you will need to make few more changes:
+
+- Click on `Generate a private key`
+  - Run `base64 -i <path_to_download_file>`
+  - Add to the deployment the variable `GH_APP_PRIVATE_KEY`
+  - Delete the file just downloaded
+- Add to the deployment the variable `GH_APP_ID`
+- Select "Install App" and install the app on your Github org
+  - Grant access to "All Repositories"
+- Look at the URL of the installation and you will find the installation ID
+  - Add to the deployment the variable `GH_APP_INSTALLATION_ID`

--- a/src/sentry_config.py
+++ b/src/sentry_config.py
@@ -10,12 +10,19 @@ SENTRY_CONFIG_RAW_URL = (
 )
 
 
-def fetch_dsn_for_github_org(org: str) -> str:
+def fetch_dsn_for_github_org(org: str, token: str) -> str:
     cp = ConfigParser()
     api_url = SENTRY_CONFIG_API_URL.replace("{owner}", org)
 
     # - Get meta about sentry_config.ini file
-    req = requests.get(api_url)
+    resp = requests.get(
+        f"https://api.github.com/repos/{org}/.sentry/contents/sentry_config.ini",
+        # Using the GH app token allows fetching the file in a private repo
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"token {token}",
+        },
+    )
     req.raise_for_status()
     resp = req.json()
 

--- a/src/sentry_config.py
+++ b/src/sentry_config.py
@@ -4,22 +4,12 @@ from configparser import ConfigParser
 
 import requests
 
-CACHE = {}
 SENTRY_CONFIG_API_URL = (
     "https://api.github.com/repos/{owner}/.sentry/contents/sentry_config.ini"
 )
 
-# Remember the last 1000 orgs
-@lru_cache(maxsize=1000)
-def _org_dsn(org):
-    return CACHE[org]
-
 
 def fetch_dsn_for_github_org(org: str, token: str) -> str:
-    if CACHE.get(org):
-        return _org_dsn(org)
-
-    print(f"The org {org} is not in the cache.")
     # Using the GH app token allows fetching the file in a private repo
     headers = {
         "Accept": "application/vnd.github+json",
@@ -41,7 +31,4 @@ def fetch_dsn_for_github_org(org: str, token: str) -> str:
     # - Read ini file and assertions
     cp = ConfigParser()
     cp.read_string(file_contents)
-    dsn = cp.get("sentry-github-actions-app", "dsn")
-    # Store in the cache
-    CACHE[org] = dsn
-    return dsn
+    return cp.get("sentry-github-actions-app", "dsn")

--- a/src/sentry_config.py
+++ b/src/sentry_config.py
@@ -3,10 +3,10 @@ from configparser import ConfigParser
 import requests
 
 SENTRY_CONFIG_API_URL = (
-    f"https://api.github.com/repos/{owner}/.sentry/contents/sentry_config.ini"
+    "https://api.github.com/repos/{owner}/.sentry/contents/sentry_config.ini"
 )
 SENTRY_CONFIG_RAW_URL = (
-    f"https://raw.githubusercontent.com/{owner}/.sentry/main/sentry_config.ini"
+    "https://raw.githubusercontent.com/{owner}/.sentry/main/sentry_config.ini"
 )
 
 

--- a/src/sentry_config.py
+++ b/src/sentry_config.py
@@ -12,7 +12,7 @@ SENTRY_CONFIG_RAW_URL = (
 
 def fetch_dsn_for_github_org(org: str) -> str:
     cp = ConfigParser()
-    api_url = SENTRY_CONFIG_API_URL.replace("owner", org)
+    api_url = SENTRY_CONFIG_API_URL.replace("{owner}", org)
 
     # - Get meta about sentry_config.ini file
     req = requests.get(api_url)

--- a/src/sentry_config.py
+++ b/src/sentry_config.py
@@ -1,0 +1,30 @@
+from configparser import ConfigParser
+
+import requests
+
+SENTRY_CONFIG_API_URL = (
+    f"https://api.github.com/repos/{owner}/.sentry/contents/sentry_config.ini"
+)
+SENTRY_CONFIG_RAW_URL = (
+    f"https://raw.githubusercontent.com/{owner}/.sentry/main/sentry_config.ini"
+)
+
+
+def fetch_dsn_for_github_org(org: str) -> str:
+    cp = ConfigParser()
+    api_url = SENTRY_CONFIG_API_URL.replace("owner", org)
+
+    # - Get meta about sentry_config.ini file
+    req = requests.get(api_url)
+    req.raise_for_status()
+    resp = req.json()
+
+    # - Fetch raw contents of file
+    download_url = resp["download_url"]
+    req = requests.get(download_url)
+    req.raise_for_status()
+    file_contents = req.text
+
+    # - Read ini file and assertions
+    cp.read_string(file_contents)
+    return cp.get("sentry-github-actions-app", "dsn")

--- a/src/sentry_config.py
+++ b/src/sentry_config.py
@@ -1,37 +1,47 @@
+import base64
+from functools import lru_cache
 from configparser import ConfigParser
 
 import requests
 
+CACHE = {}
 SENTRY_CONFIG_API_URL = (
     "https://api.github.com/repos/{owner}/.sentry/contents/sentry_config.ini"
 )
-SENTRY_CONFIG_RAW_URL = (
-    "https://raw.githubusercontent.com/{owner}/.sentry/main/sentry_config.ini"
-)
+
+# Remember the last 1000 orgs
+@lru_cache(maxsize=1000)
+def _org_dsn(org):
+    return CACHE[org]
 
 
 def fetch_dsn_for_github_org(org: str, token: str) -> str:
-    cp = ConfigParser()
+    if CACHE.get(org):
+        return _org_dsn(org)
+
+    print(f"The org {org} is not in the cache.")
+    # Using the GH app token allows fetching the file in a private repo
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"token {token}",
+    }
     api_url = SENTRY_CONFIG_API_URL.replace("{owner}", org)
-
     # - Get meta about sentry_config.ini file
-    resp = requests.get(
-        f"https://api.github.com/repos/{org}/.sentry/contents/sentry_config.ini",
-        # Using the GH app token allows fetching the file in a private repo
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"token {token}",
-        },
-    )
-    req.raise_for_status()
-    resp = req.json()
+    resp = requests.get(api_url, headers=headers)
+    resp.raise_for_status()
+    meta = resp.json()
 
-    # - Fetch raw contents of file
-    download_url = resp["download_url"]
-    req = requests.get(download_url)
-    req.raise_for_status()
-    file_contents = req.text
+    if meta["type"] != "file":
+        # XXX: custom error
+        raise Exception(meta["type"])
+
+    assert meta["encoding"] == "base64", meta["encoding"]
+    file_contents = base64.b64decode(meta["content"]).decode()
 
     # - Read ini file and assertions
+    cp = ConfigParser()
     cp.read_string(file_contents)
-    return cp.get("sentry-github-actions-app", "dsn")
+    dsn = cp.get("sentry-github-actions-app", "dsn")
+    # Store in the cache
+    CACHE[org] = dsn
+    return dsn

--- a/src/web_app_handler.py
+++ b/src/web_app_handler.py
@@ -37,7 +37,8 @@ class WebAppHandler:
 
             # e.g. "https://api.github.com/repos/getsentry/sentry/actions/workflows/1174556",
             org = data["workflow_job"]["url"].split("repos/")[1].split("/")[0]
-            dsn = fetch_dsn_for_github_org(org)
+            # Once the Sentry org has a .sentry repo we can remove the DSN from the deployment
+            dsn = os.environ.get("SENTRY_GITHUB_DSN", fetch_dsn_for_github_org(org))
 
             # We are executing in Github App mode
             if self.config.gh_app:

--- a/src/web_app_handler.py
+++ b/src/web_app_handler.py
@@ -42,10 +42,10 @@ class WebAppHandler:
 
             # We are executing in Github App mode
             if self.config.gh_app:
+
                 with GithubAppToken(
                     **self.config.gh_app._asdict()
                 ).get_token() as token:
-
                     client = GithubClient(
                         token=token,
                         dsn=dsn,

--- a/tests/test_github_sdk.py
+++ b/tests/test_github_sdk.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime
 from unittest.mock import patch
 
@@ -13,6 +14,11 @@ from src.github_sdk import GithubClient
 DSN = "https://foo@random.ingest.sentry.io/bar"
 TOKEN = "irrelevant"
 
+# Different versions of Python represent certain errors differently
+prepend = ""
+if sys.version_info[:2] >= (3, 10):
+    prepend = "GithubClient."
+
 
 def test_job_without_steps(skipped_workflow):
     sdk = GithubClient(dsn=DSN, token=TOKEN)
@@ -25,7 +31,7 @@ def test_initialize_without_setting_dsn():
     (msg,) = excinfo.value.args
     assert (
         msg
-        == "GithubClient.__init__() missing 2 required positional arguments: 'token' and 'dsn'"
+        == f"{prepend}__init__() missing 2 required positional arguments: 'token' and 'dsn'"
     )
 
 
@@ -33,9 +39,7 @@ def test_initialize_without_setting_token():
     with pytest.raises(TypeError) as excinfo:
         GithubClient(dsn=DSN)
     (msg,) = excinfo.value.args
-    assert (
-        msg == "GithubClient.__init__() missing 1 required positional argument: 'token'"
-    )
+    assert msg == f"{prepend}__init__() missing 1 required positional argument: 'token'"
 
 
 @responses.activate

--- a/tests/test_sentry_config_file.py
+++ b/tests/test_sentry_config_file.py
@@ -3,7 +3,6 @@ import responses
 
 from src.sentry_config import (
     SENTRY_CONFIG_API_URL as api_url,
-    SENTRY_CONFIG_RAW_URL as raw_url,
     fetch_dsn_for_github_org,
 )
 
@@ -18,7 +17,7 @@ sentry_config_file_meta = {
     "url": "https://api.github.com/repos/armenzg/.sentry/contents/sentry_config.ini?ref=main",
     "html_url": "https://github.com/armenzg/.sentry/blob/main/sentry_config.ini",
     "git_url": "https://api.github.com/repos/armenzg/.sentry/git/blobs/21a49641b349f82af39b3ef5f54613a556e60fcc",
-    "download_url": "https://raw.githubusercontent.com/armenzg/.sentry/main/sentry_config.ini",
+    "download_url": "https://raw.githubusercontent.com/armenzg/.sentry/main/sentry_config.ini?token=A2NWFUXUKJYCKJQXPAUSHULC6KTXLAVPNFXHG5DBNRWGC5DJN5XF62LEZYA2YZLLWFUW443UMFWGYYLUNFXW4X3UPFYGLN2JNZ2GKZ3SMF2GS33OJFXHG5DBNRWGC5DJN5XA",
     "type": "file",
     "content": "OyBUaGlzIGZpbGUgbmVlZHMgdG8gYmUgcGxhY2VkIHdpdGhpbiBhIHByaXZh\ndGUgcmVwb3NpdG9yeSBuYW1lZCAuc2VudHJ5IChpdCBjYW4gYWxzbyBiZSBt\nYWRlIHB1YmxpYykKOyBUaGlzIGZpbGUgZm9yIG5vdyB3aWxsIGNvbmZpZ3Vy\nZSB0aGUgc2VudHJ5LWdpdGh1Yi1hY3Rpb25zLWFwcAo7IGJ1dCBpdCBtYXli\nZSB1c2VkIGJ5IGZ1dHVyZSBTZW50cnkgc2VydmljZXMKCjsgVGhpcyBjb25m\naWd1cmVzIGh0dHBzOi8vZ2l0aHViLmNvbS9nZXRzZW50cnkvc2VudHJ5LWdp\ndGh1Yi1hY3Rpb25zLWFwcAo7IEZvciBub3cgaXQgaXMgb25seSB1c2VkIHRv\nIGNvbmZpZ3VyZSB0aGUgcHJvamVjdCB5b3Ugd2FudCB5b3VyIG9yZydzIENJ\nCjsgdG8gcG9zdCB0cmFuc2FjdGlvbnMgdG8KW3NlbnRyeS1naXRodWItYWN0\naW9ucy1hcHBdCjsgVGhpcyBwcm9qZWN0IGlzIHVuZGVyIHNlbnRyeS1lY29z\neXN0ZW0gb3JnCjsgaHR0cHM6Ly9zZW50cnkuaW8vb3JnYW5pemF0aW9ucy9z\nZW50cnktZWNvc3lzdGVtL3BlcmZvcm1hbmNlLz9wcm9qZWN0PTY2Mjc1MDcK\nZHNuID0gaHR0cHM6Ly83MzgwNWVlMGE2Nzk0MzhkOTA5YmIwZTZlMDVmYjk3\nZkBvNTEwODIyLmluZ2VzdC5zZW50cnkuaW8vNjYyNzUwNw==\n",
     "encoding": "base64",
@@ -28,25 +27,21 @@ sentry_config_file_meta = {
         "html": "https://github.com/armenzg/.sentry/blob/main/sentry_config.ini",
     },
 }
-
-sentry_config_ini_file = f"[sentry-github-actions-app]\ndsn = {expected_dsn}"
+org = "armenzg"
+token = "foo_token"
 
 
 class TestSentryConfigCase(TestCase):
     def setUp(self) -> None:
-        self.api_url = api_url.replace("{owner}", "armenzg")
-        self.raw_url = raw_url.replace("{owner}", "armenzg")
+        self.api_url = api_url.replace("{owner}", org)
         responses.add(
             method="GET", url=self.api_url, json=sentry_config_file_meta, status=200
-        )
-        responses.add(
-            method="GET", url=self.raw_url, body=sentry_config_ini_file, status=200
         )
         return super().setUp()
 
     @responses.activate
     def test_fetch_parse_sentry_config_file(self) -> None:
-        assert fetch_dsn_for_github_org("armenzg") == expected_dsn
+        assert fetch_dsn_for_github_org(org, token) == expected_dsn
 
     def test_fetch_private_repo(self) -> None:
         pass

--- a/tests/test_sentry_config_file.py
+++ b/tests/test_sentry_config_file.py
@@ -1,0 +1,54 @@
+import responses
+
+from src.sentry_config import (
+    SENTRY_CONFIG_API_URL as api_url,
+    SENTRY_CONFIG_RAW_URL as raw_url,
+    fetch_dsn_for_github_org,
+)
+
+expected_dsn = (
+    "https://73805ee0a679438d909bb0e6e05fb97f@o510822.ingest.sentry.io/6627507"
+)
+sentry_config_file_meta = {
+    "name": "sentry_config.ini",
+    "path": "sentry_config.ini",
+    "sha": "21a49641b349f82af39b3ef5f54613a556e60fcc",
+    "size": 619,
+    "url": "https://api.github.com/repos/armenzg/.sentry/contents/sentry_config.ini?ref=main",
+    "html_url": "https://github.com/armenzg/.sentry/blob/main/sentry_config.ini",
+    "git_url": "https://api.github.com/repos/armenzg/.sentry/git/blobs/21a49641b349f82af39b3ef5f54613a556e60fcc",
+    "download_url": "https://raw.githubusercontent.com/armenzg/.sentry/main/sentry_config.ini",
+    "type": "file",
+    "content": "OyBUaGlzIGZpbGUgbmVlZHMgdG8gYmUgcGxhY2VkIHdpdGhpbiBhIHByaXZh\ndGUgcmVwb3NpdG9yeSBuYW1lZCAuc2VudHJ5IChpdCBjYW4gYWxzbyBiZSBt\nYWRlIHB1YmxpYykKOyBUaGlzIGZpbGUgZm9yIG5vdyB3aWxsIGNvbmZpZ3Vy\nZSB0aGUgc2VudHJ5LWdpdGh1Yi1hY3Rpb25zLWFwcAo7IGJ1dCBpdCBtYXli\nZSB1c2VkIGJ5IGZ1dHVyZSBTZW50cnkgc2VydmljZXMKCjsgVGhpcyBjb25m\naWd1cmVzIGh0dHBzOi8vZ2l0aHViLmNvbS9nZXRzZW50cnkvc2VudHJ5LWdp\ndGh1Yi1hY3Rpb25zLWFwcAo7IEZvciBub3cgaXQgaXMgb25seSB1c2VkIHRv\nIGNvbmZpZ3VyZSB0aGUgcHJvamVjdCB5b3Ugd2FudCB5b3VyIG9yZydzIENJ\nCjsgdG8gcG9zdCB0cmFuc2FjdGlvbnMgdG8KW3NlbnRyeS1naXRodWItYWN0\naW9ucy1hcHBdCjsgVGhpcyBwcm9qZWN0IGlzIHVuZGVyIHNlbnRyeS1lY29z\neXN0ZW0gb3JnCjsgaHR0cHM6Ly9zZW50cnkuaW8vb3JnYW5pemF0aW9ucy9z\nZW50cnktZWNvc3lzdGVtL3BlcmZvcm1hbmNlLz9wcm9qZWN0PTY2Mjc1MDcK\nZHNuID0gaHR0cHM6Ly83MzgwNWVlMGE2Nzk0MzhkOTA5YmIwZTZlMDVmYjk3\nZkBvNTEwODIyLmluZ2VzdC5zZW50cnkuaW8vNjYyNzUwNw==\n",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/armenzg/.sentry/contents/sentry_config.ini?ref=main",
+        "git": "https://api.github.com/repos/armenzg/.sentry/git/blobs/21a49641b349f82af39b3ef5f54613a556e60fcc",
+        "html": "https://github.com/armenzg/.sentry/blob/main/sentry_config.ini",
+    },
+}
+
+sentry_config_ini_file = f"[sentry-github-actions-app]\ndsn = {expected_dsn}"
+
+
+class TestSentryConfigCase:
+    def setUp(self):
+        self.api_url = api_url.replace("owner", "armenzg")
+        self.raw_url = raw_url.replace("owner", "armenzg")
+
+    @responses.activate
+    def test_fetch_parse_sentry_config_file(self):
+        responses.get(self.api_url, json=sentry_config_file_meta, status=200)
+        responses.get(self.raw_url, body=sentry_config_ini_file, status=200)
+
+        dsn = fetch_dsn_for_github_org("armenzg")
+        assert dsn == expected_dsn
+
+    def test_fetch_private_repo(self):
+        pass
+
+    def test_file_missing(self):
+        pass
+
+    def test_bad_contents(self):
+        pass

--- a/tests/test_sentry_config_file.py
+++ b/tests/test_sentry_config_file.py
@@ -1,3 +1,4 @@
+from unittest import TestCase
 import responses
 
 from src.sentry_config import (
@@ -31,24 +32,27 @@ sentry_config_file_meta = {
 sentry_config_ini_file = f"[sentry-github-actions-app]\ndsn = {expected_dsn}"
 
 
-class TestSentryConfigCase:
-    def setUp(self):
-        self.api_url = api_url.replace("owner", "armenzg")
-        self.raw_url = raw_url.replace("owner", "armenzg")
+class TestSentryConfigCase(TestCase):
+    def setUp(self) -> None:
+        self.api_url = api_url.replace("{owner}", "armenzg")
+        self.raw_url = raw_url.replace("{owner}", "armenzg")
+        responses.add(
+            method="GET", url=self.api_url, json=sentry_config_file_meta, status=200
+        )
+        responses.add(
+            method="GET", url=self.raw_url, body=sentry_config_ini_file, status=200
+        )
+        return super().setUp()
 
     @responses.activate
-    def test_fetch_parse_sentry_config_file(self):
-        responses.get(self.api_url, json=sentry_config_file_meta, status=200)
-        responses.get(self.raw_url, body=sentry_config_ini_file, status=200)
+    def test_fetch_parse_sentry_config_file(self) -> None:
+        assert fetch_dsn_for_github_org("armenzg") == expected_dsn
 
-        dsn = fetch_dsn_for_github_org("armenzg")
-        assert dsn == expected_dsn
-
-    def test_fetch_private_repo(self):
+    def test_fetch_private_repo(self) -> None:
         pass
 
-    def test_file_missing(self):
+    def test_file_missing(self) -> None:
         pass
 
-    def test_bad_contents(self):
+    def test_bad_contents(self) -> None:
         pass

--- a/tests/test_web_app_handler.py
+++ b/tests/test_web_app_handler.py
@@ -64,20 +64,6 @@ def test_missing_workflow_job(monkeypatch):
     assert msg == "workflow_job"
 
 
-# "Set SENTRY_GITHUB_SDN in order to send envelopes."
-def test_no_dsn_is_set(monkeypatch):
-    monkeypatch.delenv("GH_APP_ID", raising=False)
-    handler = WebAppHandler()
-    # This tries to process a job that does not have the conclusion key
-    with pytest.raises(KeyError) as excinfo:
-        handler.handle_event(
-            data={"action": "completed", "workflow_job": {}},
-            headers={"X-GitHub-Event": "workflow_job"},
-        )
-    (msg,) = excinfo.value.args
-    assert msg == "conclusion"
-
-
 def test_valid_signature_no_secret(monkeypatch):
     monkeypatch.delenv("GH_WEBHOOK_SECRET", raising=False)
     handler = WebAppHandler()


### PR DESCRIPTION
In order to use the Github App, customers will have to create a `.sentry` repo and define their Github CI project DSN in it.

The file will be named `sentry_config.ini` and the contents will look like this:

```ini
[sentry-github-actions-app]
; DSN value of the Sentry project that will contain Github's CI data
dsn = https://foo@bar.ingest.sentry.io/foobar
```

I have installed the app under `armenzg`.
The DSN is defined in [this file](https://github.com/armenzg/.sentry/blob/main/sentry_config.ini).
The events are submitted to Sentry and can be seen [here](https://sentry.io/organizations/sentry-ecosystem/discover/results/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=6627507&query=&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29).

Fixes #37
Fixes API-2888