### PR TITLE
feat: Trace jobs over a run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,11 +40,11 @@ def uuid_list():
     return [
         "5ae279acd9824cbfa85042013cfbf8b7",
         "a401d83c7ec0495f82a8da8d9a389f5b",
-        "81b0bea6aedf4817a74d32d706908df2",
+        "4d4d3477c624836b1b3a3729a7de688a",
         "0726fb4a2341477cbfa36ebd830bd8e3",
         "a7776ed12daa449bb0642e9ea1bb4152",
         "6e147ff372f9498abb5749a1210d8e0a",
-        "498cceede5f14fd991778f007b237803",
+        "a401d83c7ec0495f82a8da8d9a389f5b",
         "a401d83c7ec0495f82a8da8d9a389f5b",
     ]
 

--- a/tests/fixtures/jobA/trace.json
+++ b/tests/fixtures/jobA/trace.json
@@ -9,7 +9,7 @@
       "op": "frontend tests (0)",
       "span_id": "a401d83c7ec0495f",
       "status": "ok",
-      "trace_id": "81b0bea6aedf4817a74d32d706908df2",
+      "trace_id": "4d4d3477c624836b1b3a3729a7de688a",
       "type": "trace"
     }
   },
@@ -19,37 +19,37 @@
       "name": "Set up job",
       "op": "Set up job",
       "parent_span_id": "a401d83c7ec0495f",
-      "span_id": "0726fb4a2341477c",
+      "span_id": "4d4d3477c624836b",
       "start_timestamp": "2022-04-06T19:52:16.000Z",
       "timestamp": "2022-04-06T19:52:20.000Z",
-      "trace_id": "81b0bea6aedf4817a74d32d706908df2"
+      "trace_id": "4d4d3477c624836b1b3a3729a7de688a"
     },
     {
       "name": "Pull ghcr.io/getsentry/action-html-to-image:latest",
       "op": "Pull ghcr.io/getsentry/action-html-to-image:latest",
       "parent_span_id": "a401d83c7ec0495f",
-      "span_id": "a7776ed12daa449b",
+      "span_id": "0726fb4a2341477c",
       "start_timestamp": "2022-04-06T19:52:20.000Z",
       "timestamp": "2022-04-06T19:52:58.000Z",
-      "trace_id": "81b0bea6aedf4817a74d32d706908df2"
+      "trace_id": "4d4d3477c624836b1b3a3729a7de688a"
     },
     {
       "name": "Post Checkout sentry",
       "op": "Post Checkout sentry",
       "parent_span_id": "a401d83c7ec0495f",
-      "span_id": "6e147ff372f9498a",
+      "span_id": "a7776ed12daa449b",
       "start_timestamp": "2022-04-06T20:05:37.000Z",
       "timestamp": "2022-04-06T20:05:35.000Z",
-      "trace_id": "81b0bea6aedf4817a74d32d706908df2"
+      "trace_id": "4d4d3477c624836b1b3a3729a7de688a"
     },
     {
       "name": "Complete job",
       "op": "Complete job",
       "parent_span_id": "a401d83c7ec0495f",
-      "span_id": "498cceede5f14fd9",
+      "span_id": "6e147ff372f9498a",
       "start_timestamp": "2022-04-06T20:05:35.000Z",
       "timestamp": "2022-04-06T20:05:35.000Z",
-      "trace_id": "81b0bea6aedf4817a74d32d706908df2"
+      "trace_id": "4d4d3477c624836b1b3a3729a7de688a"
     }
   ],
   "start_timestamp": "2022-04-06T19:52:17Z",

--- a/tests/fixtures/webhook_event.json
+++ b/tests/fixtures/webhook_event.json
@@ -11,13 +11,14 @@
     "X-GitHub-Hook-Installation-Target-ID": 873328,
     "X-GitHub-Hook-Installation-Target-Type": "repository",
     "X-Hub-Signature": "sha1=aaaeb75e9ef80af1a95ffdf4b4b8b2a69ff8ff69",
-    "X-Hub-Signature-256": "sha256=b7b02a023839f2a85b164e5732b49b939d90f42558d1cd8386e188f20648b0e8"
+    "X-Hub-Signature-256": "sha256=d9259f51d3b64e7fe0cbe09d9b08b8ee763170d3521fecc35fd8b453be8cf6a5"
   },
   "payload": {
     "action": "completed",
     "workflow_job": {
       "id": 3283437728,
       "run_id": 1113865931,
+      "run_attempt": 2,
       "run_url": "https://api.github.com/repos/armenzg/sentry-hackweek/actions/runs/1113865931",
       "node_id": "MDg6Q2hlY2tSdW4zMjgzNDM3NzI4",
       "head_sha": "2238b40c4b398874db76239c1d60325af9037563",

--- a/tests/test_github_sdk.py
+++ b/tests/test_github_sdk.py
@@ -120,7 +120,7 @@ def test_send_trace(
         "Content-Type": "application/x-sentry-envelope",
         "Content-Encoding": "gzip",
         "X-Sentry-Auth": f"Sentry sentry_key=foo,sentry_client=gha-sentry/0.0.1,sentry_timestamp={now},sentry_version=7",
-        "Content-Length": "701",
+        "Content-Length": "693",
     }
 
     for k, v in resp.request.headers.items():

--- a/tests/test_web_app_handler.py
+++ b/tests/test_web_app_handler.py
@@ -7,7 +7,7 @@ import pytest
 
 from src.web_app_handler import WebAppHandler
 
-valid_signature = "ad21e4e6a981bd1656fcd56ed0039b9ab4f292a997517e26fe77aab63920a9ad"
+valid_signature = "d9259f51d3b64e7fe0cbe09d9b08b8ee763170d3521fecc35fd8b453be8cf6a5"
 
 
 def test_invalid_header():


### PR DESCRIPTION
This PR will set trace IDs on the generated transactions based on Github `run_id` and the `run_attempt`.

This should create connected traces for all job transaction within one workflow run.